### PR TITLE
C問題:試験の合格判定

### DIFF
--- a/exercises/paiza/C問題:試験の合格判定/code.rb
+++ b/exercises/paiza/C問題:試験の合格判定/code.rb
@@ -1,0 +1,29 @@
+student_num = gets.to_i
+exam_point = []
+count_l = 0
+count_s = 0
+i = 0
+
+student_num.times do
+    exam_point[i] = gets.split(" ")
+    i += 1
+end
+
+exam_point.each do |ary|
+    if ary.include?("l")
+        ary.delete_at(0)
+        ary.map!{|i| i.to_i}
+        if ary.inject(:+)  >= 350 && ary[3] + ary[4] >= 160
+            count_l += 1
+        end
+    elsif ary.include?("s")
+        ary.delete_at(0)
+        ary.map!{|i| i.to_i}
+        if ary.inject(:+)  >= 350 && ary[1] + ary[2] >= 160
+            count_s += 1
+        end
+    end
+end
+
+puts count_s + count_l
+        


### PR DESCRIPTION
**【問題文】**
総合力を重視する paiza 大学の入試では 1 次試験 (英語、数学、理科、国語、地理歴史の 5 科目で各 100 点満点) の成績で足切りを行います。足切りを通過する条件は以下のようになっています。

全科目の合計得点が 350 点以上
理系の受験者の場合は理系 2 科目 (数学、理科) の合計得点が 160 点以上
文系の受験者の場合は文系 2 科目 (国語、地理歴史) の合計得点が 160 点以上
受験者それぞれの各科目の点数が入力されるので、何人足切りを通過できるかを求めてください。

例）

![2019-03-01 20 21 03](https://user-images.githubusercontent.com/32436625/53635154-9328e000-3c5f-11e9-95f6-a653356b3b92.png)


受験者 2 は全科目の合計は 350 点以上ですが文系 2 科目の合計が 160 点未満なので不合格。一方受験者 4 は理系 2 科目の合計は 160 点以上ですが全科目の合計が 350 点未満なので不合格となります。

→ 通過人数: 2 人

これは入力例 1 に対応しています。

-------
**【入力される値】**
入力は以下のフォーマットで与えられます。

N
t_1 e_1 m_1 s_1 j_1 g_1 
t_2 e_2 m_2 s_2 j_2 g_2
...
t_N e_N m_N s_N j_N g_N
・1 行目には受験者の人数を表す整数 N が与えられます。
・続く N 行のうち i 行目 (1 ≦ i ≦ N) には受験者の文理の区分を表す文字 t_i と、英語、数学、理科、国語、地理歴史の点数を表す整数 e_i, m_i, s_i, j_i, g_i がこの順に半角スペース区切りで与えられます。
・t_i について文系は "l" ("L" の小文字)、理系は "s" で表されます。
・入力は合計で N + 1 行となり、入力値最終行の末尾に改行が１つ入ります。

それぞれの値は文字列で標準入力から渡されます。標準入力からの値取得方法はこちらをご確認ください
期待する出力
paiza 大学の入試の足切りを何人通過できるかを整数で 1 行に出力してください。

最後は改行し、余計な文字、空行を含んではいけません。

**【条件】**
すべてのテストケースにおいて、以下の条件をみたします。

・1 ≦ N ≦ 1,000
・各 i (1 ≦ i ≦ N) について
・t_i は英字小文字で "l","s" のいずれか
・0 ≦ e_i, m_i, s_i, j_i, g_i ≦ 100

-------
**【入力例1】**
5
s 70 78 82 57 74
l 68 81 81 60 78
s 63 76 55 80 75
s 90 100 96 10 10
l 88 78 81 97 93

-------
【出力例1】
2

-------
【入力例2】
20
l 100 67 39 85 87
s 38 75 75 45 90
l 43 95 7 35 49
l 82 77 74 35 44
s 96 80 92 58 84
l 23 60 44 27 3
l 42 24 52 23 63
s 44 78 98 51 10
l 93 38 73 88 12
l 34 29 43 48 61
l 83 33 97 3 59
l 24 84 22 35 33
s 81 42 80 34 87
l 8 87 82 80 100
l 48 75 75 3 50
l 93 76 25 71 31
s 60 92 64 66 11
l 61 47 6 21 83
l 68 1 47 81 78
l 8 72 54 20 25

-------
**【出力例2】**
3